### PR TITLE
Allow duplicated name for manifest yaml

### DIFF
--- a/src/manifestList.ts
+++ b/src/manifestList.ts
@@ -399,7 +399,7 @@ export class WskDeployManifestProvider implements vscode.TreeDataProvider<WskDep
 
         try {
             const doc = fs.readFileSync(path, { encoding: 'utf8' });
-            const contents = yaml.safeLoad(doc);
+            const contents = yaml.safeLoad(doc, { json: true });
 
             if (contents === undefined) {
                 return false;

--- a/test-fixtures/valid-manifest.yaml
+++ b/test-fixtures/valid-manifest.yaml
@@ -31,7 +31,9 @@ packages:
           outputs:
             greeting: string
             details: string
-  
+        hello_world: # Duplicate name is not valid, but allowed in manifest panel
+          function: src/index.js
+
       triggers:
         meetPerson:
           inputs:


### PR DESCRIPTION
## Description
If the manifest file has the same entity name, it is not visible on the wskdeploy manifest panel because it is not a valid YAML format. 
But, even if it is not valid, it is better to show it in the side panel if it uses a wskdeploy format.

### Reference
https://github.com/nodeca/js-yaml#safeload-string---options-

> json (default: false) - compatibility with JSON.parse behaviour. If true, then duplicate keys in a mapping will override values rather than throwing an error.
